### PR TITLE
feat(DPE-5229): Fix release pipeline

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -24,7 +24,7 @@ jobs:
     uses: canonical/data-platform-workflows/.github/workflows/release_charm.yaml@v18.0.0
     with:
       channel: 6/edge
-      artifact-name: ${{ needs.build.outputs.artifact-name }}
+      artifact-prefix: ${{ needs.build.outputs.artifact-prefix }}
     secrets:
       charmhub-token: ${{ secrets.CHARMHUB_TOKEN }}
     permissions:


### PR DESCRIPTION
## Issue

 * Release pipeline is broken, it fails to run because of a workflow error.

## Solution

 * One argument name had changed, update the argument name to ensure that it works.