### PR TITLE
chore: Remove tag in upstream source

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -37,4 +37,4 @@ resources:
     type: oci-image
     description: OCI image for mongodb
     # TODO: Update sha whenever upstream rock changes
-    upstream-source: ghcr.io/canonical/charmed-mongodb:6.0.6-22.04_edge@sha256:b4b3edb805b20de471da57802643bfadbf979f112d738bc540ab148d145ddcfe
+    upstream-source: ghcr.io/canonical/charmed-mongodb@sha256:b4b3edb805b20de471da57802643bfadbf979f112d738bc540ab148d145ddcfe


### PR DESCRIPTION
## Issue

Charmcraft doesn't handle combination of tag and sha256. Same as MongoDB K8S
(https://github.com/canonical/mongodb-k8s-operator/pull/307)


## Solution

Remove the tag (sha256 is better and more accurate)