### PR TITLE
[DPE-5655] update charm to send correct port to client

### DIFF
--- a/lib/charms/mongodb/v1/mongodb_provider.py
+++ b/lib/charms/mongodb/v1/mongodb_provider.py
@@ -31,7 +31,7 @@ LIBAPI = 1
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 13
+LIBPATCH = 14
 
 logger = logging.getLogger(__name__)
 REL_NAME = "database"
@@ -372,6 +372,7 @@ class MongoDBProvider(Object):
             mongo_args["port"] = Config.MONGOS_PORT
             if self.substrate == Config.Substrate.K8S:
                 mongo_args["hosts"] = self.charm.get_mongos_hosts_for_client()
+                mongo_args["port"] = self.charm.get_mongos_port()
         else:
             mongo_args["replset"] = self.charm.app.name
 

--- a/src/charm.py
+++ b/src/charm.py
@@ -450,6 +450,15 @@ class MongosCharm(ops.CharmBase):
         units.extend(self.peers_units)
         return units
 
+    def get_mongos_port(self) -> int:
+        """Returns the port for this unit"""
+        if self.is_external_client:
+            self.node_port_manager.get_node_port(
+                port_to_match=Config.MONGOS_PORT, unit_name=self.unit.name
+            )
+
+        return Config.MONGOS_PORT
+
     def get_mongos_host(self) -> str:
         """Returns the host for mongos as a str.
 
@@ -459,7 +468,7 @@ class MongosCharm(ops.CharmBase):
         unit_id = self.unit.name.split("/")[1]
         return f"{self.app.name}-{unit_id}.{self.app.name}-endpoints"
 
-    def get_ext_mongos_hosts(self) -> Set:
+    def get_ext_mongos_hosts(self, incl_port: bool = True) -> Set:
         """Returns the ext hosts for mongos.
 
         Note: for external connections it is not enough to know the external ip, but also the
@@ -467,7 +476,7 @@ class MongosCharm(ops.CharmBase):
         """
         hosts = set()
         for unit in self.get_units():
-            hosts.add(self.get_ext_mongos_host(unit))
+            hosts.add(self.get_ext_mongos_host(unit, incl_port=incl_port))
 
         return hosts
 
@@ -513,7 +522,7 @@ class MongosCharm(ops.CharmBase):
         the app has been configured.
         """
         if self.is_external_client:
-            return self.get_ext_mongos_hosts()
+            return self.get_ext_mongos_hosts(incl_port=False)
 
         return self.get_k8s_mongos_hosts()
 


### PR DESCRIPTION
## Issue
URI's sent to clients when external connects are enabled are of the form `<external-port>:<mongos port>` which is incorrect and results in a faulty URI

## Solution
Update the port generation so it is correct i.e. just `<external-port>`