### PR TITLE
update libs minor versions

### DIFF
--- a/lib/charms/tls_certificates_interface/v3/tls_certificates.py
+++ b/lib/charms/tls_certificates_interface/v3/tls_certificates.py
@@ -305,6 +305,7 @@ from ops.model import (
     ModelError,
     Relation,
     RelationDataContent,
+    Secret,
     SecretNotFoundError,
     Unit,
 )
@@ -317,7 +318,7 @@ LIBAPI = 3
 
 # Increment this PATCH version before using `charmcraft publish-lib` or reset
 # to 0 if you are raising the major API version
-LIBPATCH = 17
+LIBPATCH = 20
 
 PYDEPS = ["cryptography", "jsonschema"]
 
@@ -1448,18 +1449,31 @@ class TLSCertificatesProvidesV3(Object):
         Returns:
             None
         """
-        provider_certificates = self.get_provider_certificates(relation_id)
-        requirer_csrs = self.get_requirer_csrs(relation_id)
+        provider_certificates = self.get_unsolicited_certificates(relation_id=relation_id)
+        for provider_certificate in provider_certificates:
+            self.on.certificate_revocation_request.emit(
+                certificate=provider_certificate.certificate,
+                certificate_signing_request=provider_certificate.csr,
+                ca=provider_certificate.ca,
+                chain=provider_certificate.chain,
+            )
+            self.remove_certificate(certificate=provider_certificate.certificate)
+
+    def get_unsolicited_certificates(
+        self, relation_id: Optional[int] = None
+    ) -> List[ProviderCertificate]:
+        """Return provider certificates for which no certificate requests exists.
+
+        Those certificates should be revoked.
+        """
+        unsolicited_certificates: List[ProviderCertificate] = []
+        provider_certificates = self.get_provider_certificates(relation_id=relation_id)
+        requirer_csrs = self.get_requirer_csrs(relation_id=relation_id)
         list_of_csrs = [csr.csr for csr in requirer_csrs]
         for certificate in provider_certificates:
             if certificate.csr not in list_of_csrs:
-                self.on.certificate_revocation_request.emit(
-                    certificate=certificate.certificate,
-                    certificate_signing_request=certificate.csr,
-                    ca=certificate.ca,
-                    chain=certificate.chain,
-                )
-                self.remove_certificate(certificate=certificate.certificate)
+                unsolicited_certificates.append(certificate)
+        return unsolicited_certificates
 
     def get_outstanding_certificate_requests(
         self, relation_id: Optional[int] = None
@@ -1965,9 +1979,10 @@ class TLSCertificatesRequiresV3(Object):
         Args:
             event (SecretExpiredEvent): Juju event
         """
-        if not event.secret.label or not event.secret.label.startswith(f"{LIBID}-"):
+        csr = self._get_csr_from_secret(event.secret)
+        if not csr:
+            logger.error("Failed to get CSR from secret %s", event.secret.label)
             return
-        csr = event.secret.get_content()["csr"]
         provider_certificate = self._find_certificate_in_relation_data(csr)
         if not provider_certificate:
             # A secret expired but we did not find matching certificate. Cleaning up
@@ -2007,3 +2022,18 @@ class TLSCertificatesRequiresV3(Object):
                 continue
             return provider_certificate
         return None
+
+    def _get_csr_from_secret(self, secret: Secret) -> str:
+        """Extract the CSR from the secret label or content.
+
+        This function is a workaround to maintain backwards compatibility
+        and fix the issue reported in
+        https://github.com/canonical/tls-certificates-interface/issues/228
+        """
+        if not (csr := secret.get_content().get("csr", "")):
+            # In versions <14 of the Lib we were storing the CSR in the label of the secret
+            # The CSR now is stored int the content of the secret, which was a breaking change
+            # Here we get the CSR if the secret was created by an app using libpatch 14 or lower
+            if secret.label and secret.label.startswith(f"{LIBID}-"):
+                csr = secret.label[len(f"{LIBID}-") :]
+        return csr


### PR DESCRIPTION
Before we release 6/stable, we want to update all libs (except data-platform-helpers) that are 

Note: we did not update to the major lib versions as these are expected to introduce breaking changes