### PR TITLE
Add docs to metadata.yaml

### DIFF
--- a/metadata.yaml
+++ b/metadata.yaml
@@ -5,6 +5,7 @@ display-name: mongos-k8s
 description: |
   mongos is a router/proxy used for sharded MongoDB clusters. This charm
   deploys and operates mongos as a charm on K8s.
+docs: https://discourse.charmhub.io/t/charmed-mongos-k8s-documentation/15817
 source: https://github.com/canonical/mongos-k8s-operator
 issues: https://github.com/canonical/mongos-k8s-operator/issues
 website:


### PR DESCRIPTION
## Issue
The Mongos K8s charm does not have a documentation home page on [Charmhub ](https://charmhub.io/mongos-k8s) yet.

## Solution
* Created a discourse topic for the landing page: https://discourse.charmhub.io/t/15817
* Added above link to `docs` field in `metadata.yaml`.