### PR TITLE
patch: remove the auto-delete config option

### DIFF
--- a/config.yaml
+++ b/config.yaml
@@ -6,10 +6,3 @@ options:
     description: "String to determine how to expose the mongos router externally from the Kubernetes cluster. Possible values: 'nodeport', 'none'"
     type: string
     default: "none"
-
-  auto-delete:
-    type: boolean
-    description: |
-      When a relation is removed, auto-delete ensures that any relevant databases
-      associated with the relation are also removed
-    default: false


### PR DESCRIPTION
## Issue
The `auto-delete` config option is no longer a desired config option in release 8

## Solution
This PR removes the `auto-delete` config option and its logic.
Now, the databases are never dropped.
This prevents unintended data loss in case of misconfiguration.