### PR TITLE
patch: bump mongo-single-kernel-library

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1377,14 +1377,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "1.7.2"
+version = "1.7.3"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration", "unit"]
 files = [
-    {file = "mongo_charms_single_kernel-1.7.2-py3-none-any.whl", hash = "sha256:f1ae5de40afbba43a3caa1ed26c616672b5f81be974eb3f8d9da5eae6e6c5b33"},
-    {file = "mongo_charms_single_kernel-1.7.2.tar.gz", hash = "sha256:ddf7dddc0d8e33794dcbe199e4dab1d710b765ba852343e80e464896308cf94b"},
+    {file = "mongo_charms_single_kernel-1.7.3-py3-none-any.whl", hash = "sha256:f246201cafd185de73612ecbd624b0bb8a983c905236f05237dc4889270dc49e"},
+    {file = "mongo_charms_single_kernel-1.7.3.tar.gz", hash = "sha256:208ac2180ec78f746b04253890a0da89e58944d4e0ed0d14c19272b77d76e0be"},
 ]
 
 [package.dependencies]
@@ -2846,4 +2846,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "a5ef3eba0b838dc9a50ccee1cb318f1db259f9aff8c4bf47f523d7659bfb4dba"
+content-hash = "9f48e3ce37fe129f20e649f5356c5a51241a099234b6f43faca2ebb9b7f1d36b"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,7 @@ requires-poetry = ">=2.0.0"
 [tool.poetry.dependencies]
 lightkube = "^0.15.3"
 python = "^3.10"
-mongo-charms-single-kernel = "1.7.2"
+mongo-charms-single-kernel = "1.7.3"
 ops = ">=2.21"
 pymongo = "^4.7.3"
 pyyaml = "^6.0.1"
@@ -47,13 +47,13 @@ codespell = "^2.2.6"
 shellcheck-py = "^0.10.0.1"
 
 [tool.poetry.group.unit.dependencies]
-mongo-charms-single-kernel = "1.7.2"
+mongo-charms-single-kernel = "1.7.3"
 coverage = {extras = ["toml"], version = "^7.5.0"}
 pytest = "^8.1.1"
 parameterized = "^0.9.0"
 
 [tool.poetry.group.integration.dependencies]
-mongo-charms-single-kernel = "1.7.2"
+mongo-charms-single-kernel = "1.7.3"
 ops = ">=2.21"
 allure-pytest = "^2.13.5"
 pymongo = "^4.7.3"


### PR DESCRIPTION
The mongo-single-kernel now includes internal user password management by config option (https://github.com/canonical/mongo-single-kernel-library/pull/88)