### PR TITLE
patch: Remove set-tls-private-key action

### DIFF
--- a/actions.yaml
+++ b/actions.yaml
@@ -1,15 +1,5 @@
 # Copyright 2024 Canonical Ltd.
 # See LICENSE file for licensing details.
-set-tls-private-key:
-  description: Set the privates key, which will be used for certificate signing requests (CSR). Run for each unit separately.
-  params:
-    external-key:
-      type: string
-      description: The content of private key for external communications with clients. Content will be auto-generated if this option is not specified.
-    internal-key:
-      type: string
-      description: The content of private key for internal communications with clients. Content will be auto-generated if this option is not specified.
-
 status-detail:
   description: Gets statuses of the charm
   params:


### PR DESCRIPTION
Removed the 'set-tls-private-key' action and its parameters from actions.yaml. After implementation of TLS V4 this action is no longer needed

