### PR TITLE
patch: Bump mongo-charms-single-kernel to v1.8.18

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1423,14 +1423,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "1.8.16"
+version = "1.8.18"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration"]
 files = [
-    {file = "mongo_charms_single_kernel-1.8.16-py3-none-any.whl", hash = "sha256:38f9bee829e71481191cb5b92f0cc96fe0fa0ceb449b40ab2f04a4cd0bd31068"},
-    {file = "mongo_charms_single_kernel-1.8.16.tar.gz", hash = "sha256:01c1f3d4ba60588e56370416370b029b7208cb7965836af72a942a1e3cf03610"},
+    {file = "mongo_charms_single_kernel-1.8.18-py3-none-any.whl", hash = "sha256:54187acd4fe2b2d9402a0f26fb89f7a0455396590285a2e7151fc79d43530c0e"},
+    {file = "mongo_charms_single_kernel-1.8.18.tar.gz", hash = "sha256:2ace3e23ce8bc559b10e5db11d7d60bba952ddc686221c2d89772384c5e6795a"},
 ]
 
 [package.dependencies]
@@ -2954,4 +2954,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "176915f1e9c755f5749bbc75628711200475e8d56f3797747d4125e1c5bc5d2e"
+content-hash = "a1be7398d68fe9e0e03d94dbe45f6a5564ec1a779386a315e2675e8e85706da1"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,7 +9,6 @@ requires-poetry = ">=2.0.0"
 [tool.poetry.dependencies]
 lightkube = "^0.15.3"
 python = "^3.10"
-mongo-charms-single-kernel = "1.8.16"
 ops = ">=2.21"
 pymongo = "^4.7.3"
 pyyaml = "^6.0.1"
@@ -19,6 +18,7 @@ data-platform-helpers = "^0.1.3"
 # FIXME: Unpin once rustc 1.76 is available at build time
 rpds-py = "<0.19"
 overrides = "^7.7.0"
+mongo-charms-single-kernel = "v1.8.18"
 
 [tool.poetry.group.charm-libs.dependencies]
 # data_platform_libs/v0/data_interfaces.py
@@ -54,7 +54,6 @@ codespell = "^2.2.6"
 shellcheck-py = "^0.10.0.1"
 
 [tool.poetry.group.integration.dependencies]
-mongo-charms-single-kernel = "1.8.16"
 ops = ">=2.21"
 allure-pytest = "^2.13.5"
 pymongo = "^4.7.3"
@@ -71,6 +70,7 @@ allure-pytest-collection-report = {git = "https://github.com/canonical/data-plat
 
 
 # Linting tools configuration
+mongo-charms-single-kernel = "v1.8.18"
 [tool.flake8]
 max-line-length = 99
 max-doc-length = 99


### PR DESCRIPTION
Automated bump of `mongo-charms-single-kernel` to version `v1.8.18` after PyPI release.