### PR TITLE
patch: Bump mongo-charms-single-kernel to version v1.8.22

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1423,14 +1423,14 @@ files = [
 
 [[package]]
 name = "mongo-charms-single-kernel"
-version = "1.8.19"
+version = "1.8.22"
 description = "Shared and reusable code for Mongo-related charms"
 optional = false
 python-versions = "<4.0,>=3.10"
 groups = ["main", "integration"]
 files = [
-    {file = "mongo_charms_single_kernel-1.8.19-py3-none-any.whl", hash = "sha256:6930c0efc6032aef107f0c61031f2b5670e37f270187be54749af389cdf0553f"},
-    {file = "mongo_charms_single_kernel-1.8.19.tar.gz", hash = "sha256:ed67da0d7ebfb69c90a0d815ef08fd0f67b3d9a3a29a376e39ae115a0de2ad2e"},
+    {file = "mongo_charms_single_kernel-1.8.22-py3-none-any.whl", hash = "sha256:3d2e381dead393496c9489775afcf37ab63e917916c0a204bac01b47b47c0523"},
+    {file = "mongo_charms_single_kernel-1.8.22.tar.gz", hash = "sha256:d1d05842dd69b9e96e6fa58405b5e39e72a7faf82baac38ab3143bbb8732e3bb"},
 ]
 
 [package.dependencies]
@@ -2954,4 +2954,4 @@ type = ["pytest-mypy"]
 [metadata]
 lock-version = "2.1"
 python-versions = "^3.10"
-content-hash = "9f6fb124fa12f25a339a99ad3c4f303dfd479db9b62569d26ca49c927d019f7f"
+content-hash = "142a63224a08574c2b4d85d025d64ae25bfab925b5e514569c787047b7273a25"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ data-platform-helpers = "^0.1.3"
 # FIXME: Unpin once rustc 1.76 is available at build time
 rpds-py = "<0.19"
 overrides = "^7.7.0"
-mongo-charms-single-kernel = "v1.8.19"
+mongo-charms-single-kernel = "v1.8.22"
 
 [tool.poetry.group.charm-libs.dependencies]
 # data_platform_libs/v0/data_interfaces.py
@@ -70,7 +70,7 @@ allure-pytest-collection-report = {git = "https://github.com/canonical/data-plat
 
 
 # Linting tools configuration
-mongo-charms-single-kernel = "v1.8.19"
+mongo-charms-single-kernel = "v1.8.22"
 [tool.flake8]
 max-line-length = 99
 max-doc-length = 99


### PR DESCRIPTION
Automated bump of mongo-charms-single-kernel to version v1.8.22 after PyPI release.

Includes:

- patch: add scheduler for TICS workflow in 6/edge by @patriciareinoso in https://github.com/canonical/mongo-single-kernel-library/pull/178
- patch: add workflow dispatch for bump library in charm repos workflow by @patriciareinoso in https://github.com/canonical/mongo-single-kernel-library/pull/167
- patch: validate private key matches certificate and config by @patriciareinoso in https://github.com/canonical/mongo-single-kernel-library/pull/177